### PR TITLE
Configure permissões de rede para uso da API no Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,6 +84,9 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        manifestPlaceholders = [
+                usesCleartextTraffic: "true"
+        ]
     }
     signingConfigs {
         debug {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
       android:allowBackup="false"
       android:theme="@style/AppTheme"
       android:usesCleartextTraffic="${usesCleartextTraffic}"
+      android:networkSecurityConfig="@xml/network_security_config"
       android:supportsRtl="true">
       <activity
         android:name=".MainActivity"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">sfismobile.antaq.gov.br</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Resumo
- define o placeholder `usesCleartextTraffic` para habilitar tráfego em claro no Manifest
- referencia um `networkSecurityConfig` dedicado no AndroidManifest
- adiciona configuração de segurança de rede permitindo acesso ao domínio sfismobile.antaq.gov.br

## Testes
- ⚠️ `./gradlew :app:lintDebug` *(falhou: SDK ausente no ambiente de CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d557907804832aad1f1b9998c857a0