### PR TITLE
Allow insecure TLS for debug builds

### DIFF
--- a/android/app/src/debug/java/com/sfismobile2/InsecureOkHttpClientFactory.kt
+++ b/android/app/src/debug/java/com/sfismobile2/InsecureOkHttpClientFactory.kt
@@ -1,0 +1,49 @@
+package com.sfismobile2
+
+import android.annotation.SuppressLint
+import com.facebook.react.modules.network.OkHttpClientFactory
+import com.facebook.react.modules.network.OkHttpClientProvider
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSession
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+import okhttp3.OkHttpClient
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+
+/**
+ * Factory usada apenas no build de debug para ignorar erros de certificado TLS.
+ * Isso permite que o app funcione em ambientes onde o tráfego HTTPS é inspecionado
+ * (como o proxy MITM do ambiente de desenvolvimento), o que causava o "Network Error"
+ * nas requisições SOAP.
+ */
+internal class InsecureOkHttpClientFactory : OkHttpClientFactory {
+
+  override fun createNewNetworkModuleClient(): OkHttpClient {
+    val trustManagers = buildTrustManagers()
+    val sslContext = SSLContext.getInstance("TLS").apply {
+      init(null, trustManagers, SecureRandom())
+    }
+
+    val builder = OkHttpClientProvider.createClientBuilder()
+      .sslSocketFactory(sslContext.socketFactory, trustManagers[0] as X509TrustManager)
+      .hostnameVerifier(InsecureHostnameVerifier)
+
+    return builder.build()
+  }
+
+  private fun buildTrustManagers(): Array<TrustManager> {
+    @SuppressLint("CustomX509TrustManager")
+    val trustAll = object : X509TrustManager {
+      override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+      override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
+      override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+    }
+    return arrayOf(trustAll)
+  }
+
+  private object InsecureHostnameVerifier : HostnameVerifier {
+    override fun verify(hostname: String?, session: SSLSession?): Boolean = true
+  }
+}

--- a/android/app/src/main/java/com/sfismobile2/MainApplication.kt
+++ b/android/app/src/main/java/com/sfismobile2/MainApplication.kt
@@ -9,6 +9,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.modules.network.OkHttpClientProvider
 
 class MainApplication : Application(), ReactApplication {
 
@@ -33,6 +34,11 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
+
+    if (BuildConfig.DEBUG) {
+      OkHttpClientProvider.setOkHttpClientFactory(InsecureOkHttpClientFactory())
+    }
+
     loadReactNative(this)
   }
 }


### PR DESCRIPTION
## Summary
- add a debug-only OkHttp client factory that trusts all certificates so HTTPS SOAP calls work when a MITM proxy is present
- register the debug factory during application start-up while keeping release builds unchanged

## Testing
- npm test -- --watch=false *(fails: react-native-gesture-handler uses ESM syntax that the current Jest setup cannot parse)*

------
https://chatgpt.com/codex/tasks/task_e_68d55d6e6c88832a9e5c37d8009340c6