### PR TITLE
Fix navigation screen options typing

### DIFF
--- a/src/screens/HomeFiscalizacao/ConsultarAutorizadas/index.tsx
+++ b/src/screens/HomeFiscalizacao/ConsultarAutorizadas/index.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { Pressable } from 'react-native';
+import { type TextStyle } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 
-import Icon from '@/components/Icon';
 import theme from '@/theme';
 import type { ConsultarAutorizadasStackParamList } from '@/types/types';
-import homeStyles from '../styles';
+import HeaderBackButton from '../components/HeaderBackButton';
 
 import ConsultarAutorizadasMenu from './MenuScreen';
 import CnpjRazao from './CnpjRazao';
@@ -16,9 +15,29 @@ import Instalacao from './Instalacao';
 
 const Stack = createNativeStackNavigator<ConsultarAutorizadasStackParamList>();
 
+const headerTitleStyle = {
+  fontSize: 18,
+  fontWeight: '600',
+} satisfies Pick<TextStyle, 'fontSize' | 'fontWeight'>;
+
+const baseScreenOptions: NativeStackNavigationOptions = {
+  headerStyle: { backgroundColor: theme.colors.primaryDark },
+  headerTitleStyle,
+  headerTintColor: theme.colors.surface,
+  headerTitleAlign: 'center',
+};
+
+const createHeaderLeft = (onPress: () => void): NativeStackNavigationOptions['headerLeft'] =>
+  () => <HeaderBackButton onPress={onPress} />;
+
 export default function ConsultarAutorizadasNavigator(): React.JSX.Element {
   return (
-    <Stack.Navigator screenOptions={({ navigation }) => screenOptions(navigation)}>
+    <Stack.Navigator
+      screenOptions={({ navigation }): NativeStackNavigationOptions => ({
+        ...baseScreenOptions,
+        headerLeft: createHeaderLeft(() => navigation.goBack()),
+      })}
+    >
       <Stack.Screen name="Menu" component={ConsultarAutorizadasMenu} options={{ headerShown: false }} />
       <Stack.Screen name="CnpjRazao" component={CnpjRazao} options={{ title: 'Por CNPJ / Razão Social' }} />
       <Stack.Screen name="Modalidade" component={Modalidade} options={{ title: 'Por Modalidade' }} />
@@ -26,27 +45,5 @@ export default function ConsultarAutorizadasNavigator(): React.JSX.Element {
       <Stack.Screen name="Instalacao" component={Instalacao} options={{ title: 'Por Instalação' }} />
     </Stack.Navigator>
   );
-}
-
-function screenOptions(
-  navigation: NativeStackNavigationProp<ConsultarAutorizadasStackParamList>,
-) {
-  return {
-    headerStyle: { backgroundColor: theme.colors.primaryDark },
-    headerTitleStyle: { fontSize: 18, fontWeight: '600' },
-    headerTintColor: theme.colors.surface,
-    headerTitleAlign: 'center' as const,
-    headerLeft: () => (
-      <Pressable
-        onPress={() => navigation.goBack()}
-        accessibilityRole="button"
-        accessibilityLabel="Voltar"
-        style={homeStyles.headerButton}
-        hitSlop={8}
-      >
-        <Icon name="arrow-back" size={24} color={theme.colors.surface} />
-      </Pressable>
-    ),
-  };
 }
 

--- a/src/screens/HomeFiscalizacao/components/HeaderBackButton.tsx
+++ b/src/screens/HomeFiscalizacao/components/HeaderBackButton.tsx
@@ -1,0 +1,24 @@
+import { Pressable } from 'react-native';
+
+import Icon from '@/components/Icon';
+import theme from '@/theme';
+
+import homeStyles from '../styles';
+
+type HeaderBackButtonProps = {
+  onPress: () => void;
+};
+
+export default function HeaderBackButton({ onPress }: HeaderBackButtonProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="Voltar"
+      style={homeStyles.headerButton}
+      hitSlop={8}
+    >
+      <Icon name="arrow-back" size={24} color={theme.colors.surface} />
+    </Pressable>
+  );
+}

--- a/src/screens/HomeFiscalizacao/index.tsx
+++ b/src/screens/HomeFiscalizacao/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable } from 'react-native';
+import { type TextStyle } from 'react-native';
 import {
   createDrawerNavigator,
   DrawerContentComponentProps,
@@ -28,7 +28,7 @@ import Tutorial from './Tutorial';
 import NovidadesVersao from './NovidadesVersao';
 import SituacaoServico from './SituacaoServico';
 import Notificacoes from './Notificacoes';
-import homeStyles from './styles';
+import HeaderBackButton from './components/HeaderBackButton';
 
 const Drawer = createDrawerNavigator<DrawerParamList>();
 
@@ -37,26 +37,24 @@ const makeDrawerIcon =
   ({ color, size }: { color: string; size: number }) =>
     <Icon name={name} color={color} size={size} />;
 
+const headerTitleStyle = {
+  fontSize: 18,
+  fontWeight: '600',
+} satisfies Pick<TextStyle, 'fontSize' | 'fontWeight'>;
+
+const createHeaderLeft = (onPress: () => void): DrawerNavigationOptions['headerLeft'] =>
+  () => <HeaderBackButton onPress={onPress} />;
+
 const defaultScreenOptions = ({
   navigation,
 }: {
   navigation: DrawerNavigationProp<DrawerParamList>;
 }): DrawerNavigationOptions => ({
   headerStyle: { backgroundColor: theme.colors.primaryDark },
-  headerTitleStyle: { fontSize: 18, fontWeight: '600' },
+  headerTitleStyle,
   headerTitleAlign: 'center',
   drawerActiveTintColor: theme.colors.primaryDark,
-  headerLeft: () => (
-    <Pressable
-      onPress={() => navigation.goBack()}
-      accessibilityRole="button"
-      accessibilityLabel="Voltar"
-      style={homeStyles.headerButton}
-      hitSlop={8}
-    >
-      <Icon name="arrow-back" size={24} color={theme.colors.surface} />
-    </Pressable>
-  ),
+  headerLeft: createHeaderLeft(() => navigation.goBack()),
   swipeEnabled: false,
 });
 


### PR DESCRIPTION
## Summary
- ensure the consultar autorizadas stack uses typed screen options and shared header styling helpers
- extract a reusable header back button for fiscalização screens and reuse it in the drawer navigator

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8c1e99070832abb274d9b593f53f3