### PR TITLE
Migrar telas de consulta de empresas do legado Cordova

### DIFF
--- a/src/screens/HomeFiscalizacao/ConsultarAutorizadas/Instalacao/index.tsx
+++ b/src/screens/HomeFiscalizacao/ConsultarAutorizadas/Instalacao/index.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { View, TextInput, Pressable, Text, FlatList, StyleSheet, Alert } from 'react-native';
+import { TextInput, Pressable, Text, FlatList, StyleSheet, Alert } from 'react-native';
 import theme from '@/theme';
 import { consultarPorInstalacao, Empresa } from '@/api/consultarEmpresas';
+import EmpresaCard from '../components/EmpresaCard';
+import { hasText } from '@/utils/formatters';
 
 export default function Instalacao() {
   const [query, setQuery] = useState('');
@@ -10,6 +12,10 @@ export default function Instalacao() {
   const [loading, setLoading] = useState(false);
 
   const handleSearch = async () => {
+    if (!hasText(query)) {
+      Alert.alert('Atenção', 'Informe o nome da instalação.');
+      return;
+    }
     try {
       setLoading(true);
       const result = await consultarPorInstalacao(query);
@@ -27,21 +33,34 @@ export default function Instalacao() {
       <TextInput
         value={query}
         onChangeText={setQuery}
-        placeholder="Instalação"
+        placeholder="Nome da instalação"
+        autoCapitalize="characters"
+        autoCorrect={false}
         style={styles.input}
+        editable={!loading}
       />
-      <Pressable style={styles.button} onPress={handleSearch} disabled={loading}>
+      <Pressable
+        style={({ pressed }) => [
+          styles.button,
+          (pressed || loading) && styles.buttonPressed,
+          !hasText(query) && styles.buttonDisabled,
+        ]}
+        onPress={handleSearch}
+        disabled={loading || !hasText(query)}
+      >
         <Text style={styles.buttonText}>{loading ? 'Pesquisando...' : 'Pesquisar'}</Text>
       </Pressable>
       <FlatList
         data={data}
         keyExtractor={(item, index) => `${item.NRInscricao}-${index}`}
-        renderItem={({ item }) => (
-          <View style={styles.item}>
-            <Text style={styles.itemTitle}>{item.NORazaoSocial}</Text>
-            <Text style={styles.itemSubtitle}>CNPJ: {item.NRInscricao}</Text>
-          </View>
-        )}
+        renderItem={({ item }) => <EmpresaCard empresa={item} />}
+        ListHeaderComponent={
+          data.length > 0 ? (
+            <Text style={styles.count}>
+              {data.length === 1 ? '1 empresa encontrada.' : `${data.length} empresas encontradas.`}
+            </Text>
+          ) : null
+        }
         ListEmptyComponent={!loading ? (
           <Text style={styles.empty}>Nenhuma empresa encontrada.</Text>
         ) : null}
@@ -67,9 +86,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: theme.spacing.md,
   },
+  buttonPressed: { opacity: 0.85 },
+  buttonDisabled: { opacity: 0.5 },
   buttonText: { ...theme.typography.button },
-  item: { paddingVertical: theme.spacing.sm, borderBottomWidth: 1, borderBottomColor: theme.colors.background },
-  itemTitle: { fontWeight: '600', color: theme.colors.text },
-  itemSubtitle: { color: theme.colors.muted },
   empty: { textAlign: 'center', color: theme.colors.muted, marginTop: theme.spacing.md },
+  count: { ...theme.typography.caption, color: theme.colors.muted, marginBottom: theme.spacing.sm },
 });

--- a/src/screens/HomeFiscalizacao/ConsultarAutorizadas/components/EmpresaCard.tsx
+++ b/src/screens/HomeFiscalizacao/ConsultarAutorizadas/components/EmpresaCard.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { Empresa } from '@/api/consultarEmpresas';
+import theme from '@/theme';
+import { formatCnpj, formatDate } from '@/utils/formatters';
+
+type Props = {
+  empresa: Empresa;
+};
+
+export default function EmpresaCard({ empresa }: Props) {
+  const travessia = (empresa.Modalidade ?? '').toLowerCase().includes('travessia');
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{empresa.NORazaoSocial}</Text>
+      <Text style={styles.subtitle}>
+        CNPJ: {formatCnpj(empresa.NRInscricao)}
+        {empresa.SGUF ? ` • ${empresa.SGUF}` : ''}
+        {empresa.NOMunicipio ? ` - ${empresa.NOMunicipio}` : ''}
+        {empresa.isAutoridadePortuaria ? ' • Autoridade Portuária' : ''}
+      </Text>
+
+      {!!empresa.DSEndereco && (
+        <Text style={styles.row}>
+          Endereço: <Text style={styles.emphasis}>{empresa.DSEndereco}</Text>
+        </Text>
+      )}
+
+      {!!empresa.Modalidade && (
+        <Text style={styles.row}>
+          Modalidade: <Text style={styles.emphasis}>{empresa.Modalidade}</Text>
+        </Text>
+      )}
+
+      {!!empresa.DescricaoNRInstrumento && (
+        <Text style={styles.row}>{empresa.DescricaoNRInstrumento}</Text>
+      )}
+
+      {!!formatDate(empresa.DTAditamento) && (
+        <Text style={styles.row}>
+          Data Último Aditamento: <Text style={styles.emphasis}>{formatDate(empresa.DTAditamento)}</Text>
+        </Text>
+      )}
+
+      {!!empresa.NRAditamento && (
+        <Text style={styles.row}>
+          Termo: <Text style={styles.emphasis}>{empresa.NRAditamento}</Text>
+        </Text>
+      )}
+
+      {typeof empresa.QTDEmbarcacao === 'number' && (
+        <Text style={styles.row}>
+          Embarcações: <Text style={styles.emphasis}>{empresa.QTDEmbarcacao}</Text>
+        </Text>
+      )}
+
+      {!!empresa.Instalacao && (
+        <Text style={styles.row}>
+          {travessia ? 'Travessia' : 'Instalação'}: <Text style={styles.emphasis}>{empresa.Instalacao}</Text>
+        </Text>
+      )}
+
+      {!!empresa.NRInscricaoInstalacao && empresa.NRInscricaoInstalacao !== empresa.NRInscricao && (
+        <Text style={styles.row}>
+          CNPJ Instalação: <Text style={styles.emphasis}>{formatCnpj(empresa.NRInscricaoInstalacao)}</Text>
+        </Text>
+      )}
+
+      {!!empresa.NORazaoSocialInstalacao && empresa.NRInscricaoInstalacao !== empresa.NRInscricao && (
+        <Text style={styles.row}>
+          Razão Social Instalação: <Text style={styles.emphasis}>{empresa.NORazaoSocialInstalacao}</Text>
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    paddingVertical: theme.spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: theme.colors.background,
+    gap: 2,
+  },
+  title: { fontWeight: '600', color: theme.colors.text },
+  subtitle: { color: theme.colors.muted },
+  row: { color: theme.colors.muted },
+  emphasis: { color: theme.colors.text, fontWeight: '600' },
+});
+

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,21 @@
+export function formatCnpj(raw: string): string {
+  const digits = (raw ?? '').replace(/\D/g, '');
+  if (digits.length !== 14) return raw;
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
+}
+
+export function formatDate(raw?: string): string {
+  if (!raw || raw.startsWith('01/01/1900')) return '';
+  const [day, month, rest] = raw.split('/');
+  const [year] = (rest ?? '').split(' ');
+  if (!day || !month || !year) return raw ?? '';
+  return `${day}/${month}/${year}`;
+}
+
+export function formatImoCapitania(raw: string): string {
+  return (raw ?? '').replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+}
+
+export function hasText(value: string): boolean {
+  return value.trim().length > 0;
+}


### PR DESCRIPTION
## Summary
- migrar a listagem das consultas de empresas para um card reutilizável com os mesmos campos do legado Cordova
- adicionar utilitários de formatação para CNPJ, datas e número IMO/Nº Capitania
- ajustar as telas de CNPJ/Razão, Modalidade, Embarcação e Instalação com validações, contagem de resultados e campos equivalentes ao fluxo Cordova

## Testing
- npm run lint *(falha devido a alertas de lint herdados na pasta `cordova legado`)*

------
https://chatgpt.com/codex/tasks/task_e_68d99d8ec9b0832a8c8c06105490707e