### PR TITLE
Gera imagem offline do mapa a partir do Google Static Maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.11",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.23.1",
+        "@react-native-community/netinfo": "^11.4.1",
         "@react-native/new-app-screen": "0.81.4",
         "@react-navigation/drawer": "^7.1.1",
         "@react-navigation/native": "^7.0.14",
@@ -23,6 +24,7 @@
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.9.0",
         "react-native-vector-icons": "^10.3.0",
+        "react-native-webview": "^13.16.0",
         "toastify-react-native": "^7.2.3",
         "xmlbuilder2": "^3.1.1"
       },
@@ -3000,6 +3002,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
+      "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -10758,6 +10769,20 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
+      "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-native-community/netinfo": "^11.4.1",
     "@react-native/new-app-screen": "0.81.4",
     "@react-navigation/drawer": "^7.1.1",
     "@react-navigation/native": "^7.0.14",
@@ -25,6 +26,7 @@
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.9.0",
     "react-native-vector-icons": "^10.3.0",
+    "react-native-webview": "^13.16.0",
     "toastify-react-native": "^7.2.3",
     "xmlbuilder2": "^3.1.1"
   },

--- a/src/api/consultarInstalacoesPortuarias.ts
+++ b/src/api/consultarInstalacoesPortuarias.ts
@@ -1,0 +1,117 @@
+import { extractSoapResult, soapRequest } from '@/api/antaq';
+
+export type InstalacaoPortuaria = {
+  id?: string;
+  nome: string;
+  localizacao?: string;
+  latitude?: string;
+  longitude?: string;
+  modalidade?: string;
+  situacao?: string;
+  regiaoHidrografica?: string;
+  endereco?: string;
+  cidade?: string;
+  estado?: string;
+  pais?: string;
+  cep?: string;
+  numero?: string;
+  complemento?: string;
+  gestao?: string;
+  fonte?: string;
+  tipo?: string;
+  profundidade?: string;
+  cnpj?: string;
+  cdTerminal?: string;
+  cdInstalacaoPortuaria?: string;
+};
+
+type ConsultaPayload = {
+  cnpj?: string;
+  Nome?: string;
+  DSEndereco?: string;
+  TPInstalacaoPortuaria?: string;
+  localizacao?: string;
+  cdinstalacaoportuaria?: string;
+  VLLatitude?: string;
+  VLLongitude?: string;
+};
+
+const EMPTY_PAYLOAD: ConsultaPayload = {
+  Nome: '',
+  DSEndereco: '',
+  TPInstalacaoPortuaria: '',
+  localizacao: '',
+  cdinstalacaoportuaria: '',
+  VLLatitude: '',
+  VLLongitude: '',
+};
+
+const digitsOnly = (value?: string) => (value ? value.replace(/\D/g, '') : undefined);
+
+const str = (value: any): string => {
+  if (value == null) return '';
+  if (typeof value === 'object' && value['@_nil']) return '';
+  return String(value);
+};
+
+export async function consultarInstalacoesPortuarias({
+  cnpj,
+  instalacao,
+  modalidade,
+}: {
+  cnpj?: string;
+  instalacao?: string;
+  modalidade?: string;
+}): Promise<InstalacaoPortuaria[]> {
+  const payload: ConsultaPayload = {
+    ...EMPTY_PAYLOAD,
+    cnpj: digitsOnly(cnpj) ?? '',
+  };
+
+  if (instalacao?.trim()) {
+    payload.Nome = instalacao.trim();
+    payload.localizacao = instalacao.trim();
+  }
+
+  if (modalidade?.trim()) {
+    payload.TPInstalacaoPortuaria = modalidade.trim();
+  }
+
+  const parsed = await soapRequest('ConsultarInstalacoesPortuarias', payload);
+  const result = extractSoapResult(parsed, 'ConsultarInstalacoesPortuarias');
+
+  const items = Array.isArray(result?.d)
+    ? result?.d
+    : Array.isArray(result)
+      ? result
+      : [result?.d ?? result].filter(Boolean);
+
+  return items.map(mapInstalacaoPortuaria);
+}
+
+function mapInstalacaoPortuaria(raw: any): InstalacaoPortuaria {
+  return {
+    id: str(raw?.id ?? raw?.ID),
+    nome: str(raw?.nome ?? raw?.Nome),
+    localizacao: str(raw?.localizacao ?? raw?.Localizacao),
+    latitude: str(raw?.latitude ?? raw?.Latitude ?? raw?.VLLatitude),
+    longitude: str(raw?.longitude ?? raw?.Longitude ?? raw?.VLLongitude),
+    modalidade: str(raw?.modalidade ?? raw?.Modalidade ?? raw?.TPInstalacaoPortuaria),
+    situacao: str(raw?.situacao ?? raw?.Situacao),
+    regiaoHidrografica: str(raw?.regiaohidrografica ?? raw?.RegiaoHidrografica),
+    endereco: str(raw?.endereco ?? raw?.Endereco),
+    cidade: str(raw?.cidade ?? raw?.Cidade),
+    estado: str(raw?.estado ?? raw?.Estado ?? raw?.UF),
+    pais: str(raw?.pais ?? raw?.Pais),
+    cep: str(raw?.cep ?? raw?.CEP),
+    numero: str(raw?.numero ?? raw?.Numero),
+    complemento: str(raw?.complemento ?? raw?.Complemento),
+    gestao: str(raw?.gestao ?? raw?.Gestao),
+    fonte: str(raw?.fonte ?? raw?.Fonte),
+    tipo: str(raw?.tipo ?? raw?.Tipo),
+    profundidade: str(raw?.profundidade ?? raw?.Profundidade),
+    cnpj: str(raw?.cnpj ?? raw?.CNPJ),
+    cdTerminal: str(raw?.cdterminal ?? raw?.CDTerminal),
+    cdInstalacaoPortuaria: str(raw?.cdinstalacaoportuaria ?? raw?.CDInstalacaoPortuaria),
+  };
+}

--- a/src/screens/HomeFiscalizacao/ConsultarAutorizadas/Detalhes/index.tsx
+++ b/src/screens/HomeFiscalizacao/ConsultarAutorizadas/Detalhes/index.tsx
@@ -44,6 +44,7 @@ export default function Detalhes(): React.JSX.Element {
 
   const empresa = useMemo<Empresa>(() => route.params.empresa, [route.params.empresa]);
   const fluxo = useMemo<FluxoMigracao>(() => mapearFluxoMigracao(empresa), [empresa]);
+  const isFluxoMapa = fluxo.tipo === 'MAPA';
   const instrumento = useMemo(() => {
     const descricao = empresa.DescricaoNRInstrumento?.trim();
     if (descricao) return descricao;
@@ -53,6 +54,10 @@ export default function Detalhes(): React.JSX.Element {
   const handleAbrirRotina = useCallback(() => {
     drawerNavigation?.navigate('FiscalizacaoRotina');
   }, [drawerNavigation]);
+
+  const handleAbrirMapa = useCallback(() => {
+    navigation.navigate('Mapa', { empresa });
+  }, [empresa, navigation]);
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
@@ -101,6 +106,22 @@ export default function Detalhes(): React.JSX.Element {
               </View>
             </View>
           ))}
+
+          {isFluxoMapa ? (
+            <>
+              <Pressable
+                onPress={handleAbrirMapa}
+                style={({ pressed }) => [styles.mapButton, pressed && styles.mapButtonPressed]}
+                accessibilityRole="button"
+                accessibilityLabel="Abrir mapa da instalação"
+              >
+                <Text style={styles.mapButtonText}>Visualizar mapa da instalação</Text>
+              </Pressable>
+              <Text style={styles.mapHelper}>
+                O mapa utiliza a API Google Maps v3.53. Sempre que você o abre conectado, uma imagem atualizada fica salva para uso offline.
+              </Text>
+            </>
+          ) : null}
         </View>
 
         <View style={styles.section}>
@@ -183,6 +204,16 @@ const styles = StyleSheet.create({
   stepTitle: { ...theme.typography.body, fontWeight: '600' },
   stepDescription: { ...theme.typography.body, color: theme.colors.muted },
   stepReference: { ...theme.typography.caption, color: theme.colors.muted, fontStyle: 'italic' },
+  mapButton: {
+    marginTop: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radius.sm,
+    alignItems: 'center',
+  },
+  mapButtonPressed: { opacity: 0.85 },
+  mapButtonText: { ...theme.typography.button },
+  mapHelper: { ...theme.typography.caption, color: theme.colors.muted },
   actionButton: {
     backgroundColor: theme.colors.primary,
     paddingVertical: theme.spacing.sm,

--- a/src/screens/HomeFiscalizacao/ConsultarAutorizadas/Mapa/index.tsx
+++ b/src/screens/HomeFiscalizacao/ConsultarAutorizadas/Mapa/index.tsx
@@ -1,0 +1,613 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, FlatList, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import NetInfo from '@react-native-community/netinfo';
+import { WebView } from 'react-native-webview';
+
+import theme from '@/theme';
+import type { ConsultarAutorizadasStackParamList } from '@/types/types';
+import type { Empresa } from '@/api/consultarEmpresas';
+import {
+  consultarInstalacoesPortuarias,
+  type InstalacaoPortuaria,
+} from '@/api/consultarInstalacoesPortuarias';
+import {
+  carregarInstalacoesCache,
+  salvarInstalacoesCache,
+  type InstalacoesCache,
+} from '@/services/instalacoesCache';
+import { parseCoordenada } from '@/utils/geo';
+import {
+  atualizarMapaSnapshot,
+  carregarMapaSnapshot,
+  snapshotEhAntigo,
+  type MapSnapshot,
+} from '@/services/mapSnapshotCache';
+
+type MapaRouteProp = RouteProp<ConsultarAutorizadasStackParamList, 'Mapa'>;
+
+type DataSource = 'online' | 'cache' | 'cache-stale' | 'empty';
+
+type TerminalInfo = {
+  terminal: InstalacaoPortuaria;
+  lat: number;
+  lng: number;
+};
+
+type PreferenciasInstalacao = {
+  instalacao?: string;
+  razaoSocialInstalacao?: string;
+  razaoSocialEmpresa?: string;
+  inscricaoInstalacao?: string;
+  inscricaoEmpresa?: string;
+};
+
+const GOOGLE_MAPS_URL =
+  'https://maps.googleapis.com/maps/api/js?v=3.53&key=AIzaSyBByE0Uc7WXYndpyTk_3he-TqgSQ4Pyhbw&callback=initMap';
+
+const GOOGLE_STATIC_DEFAULT_ZOOM = 13;
+
+const collapseSpaces = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const removeDiacritics = (value: string) => value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+const normalizeTexto = (value?: string) => {
+  if (!value) return '';
+  return removeDiacritics(collapseSpaces(value)).toLowerCase();
+};
+
+const normalizeCodigo = (value?: string) => {
+  if (!value) return '';
+  return removeDiacritics(value).replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+};
+
+const temCoordenadasValidas = (instalacao: InstalacaoPortuaria): boolean =>
+  parseCoordenada(instalacao.latitude) != null && parseCoordenada(instalacao.longitude) != null;
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+function pickTerminal(
+  lista: InstalacaoPortuaria[],
+  preferencia: PreferenciasInstalacao,
+): number {
+  if (!lista.length) return -1;
+  const candidatosPreferidos = [
+    normalizeTexto(preferencia.instalacao),
+    normalizeTexto(preferencia.razaoSocialInstalacao),
+    normalizeTexto(preferencia.razaoSocialEmpresa),
+  ].filter(Boolean);
+
+  const codigosPreferidos = [
+    normalizeCodigo(preferencia.inscricaoInstalacao),
+    normalizeCodigo(preferencia.inscricaoEmpresa),
+  ].filter(Boolean);
+
+  const buscarIndice = (criterio: (item: InstalacaoPortuaria) => boolean) =>
+    lista.findIndex((item) => criterio(item));
+
+  const tentaPorPreferencia = (exigirCoordenadas: boolean) =>
+    buscarIndice((item) => {
+      if (exigirCoordenadas && !temCoordenadasValidas(item)) {
+        return false;
+      }
+      const nome = normalizeTexto(item.nome);
+      const local = normalizeTexto(item.localizacao);
+      const codigo = normalizeCodigo(item.cdInstalacaoPortuaria) || normalizeCodigo(item.cdTerminal);
+
+      return (
+        candidatosPreferidos.some((alvo) => alvo === nome || alvo === local) ||
+        (codigo && codigosPreferidos.some((alvo) => alvo === codigo))
+      );
+    });
+
+  const indicePreferidoComCoordenadas = tentaPorPreferencia(true);
+  if (indicePreferidoComCoordenadas >= 0) return indicePreferidoComCoordenadas;
+
+  const indicePreferido = tentaPorPreferencia(false);
+  if (indicePreferido >= 0) return indicePreferido;
+
+  const primeiroComCoordenadas = buscarIndice((item) => temCoordenadasValidas(item));
+  if (primeiroComCoordenadas >= 0) return primeiroComCoordenadas;
+
+  return 0;
+}
+
+function formatEndereco(instalacao: InstalacaoPortuaria): string {
+  const partes = [instalacao.endereco, instalacao.numero]
+    .map((parte) => (parte ?? '').trim())
+    .filter(Boolean);
+  const linha1 = partes.join(', ');
+  const linha2 = [instalacao.cidade, instalacao.estado].map((parte) => (parte ?? '').trim()).filter(Boolean).join(' - ');
+  const extras = [instalacao.pais, instalacao.cep].map((parte) => (parte ?? '').trim()).filter(Boolean).join(' • ');
+  return [linha1, linha2, extras].filter(Boolean).join('\n');
+}
+
+function construirInfoHtml(instalacao: InstalacaoPortuaria, empresa: Empresa): string {
+  const linhas: string[] = [];
+  if (instalacao.situacao) linhas.push(`Situação: ${instalacao.situacao}`);
+  if (instalacao.modalidade) linhas.push(`Modalidade: ${instalacao.modalidade}`);
+  if (instalacao.regiaoHidrografica) linhas.push(`Região hidrográfica: ${instalacao.regiaoHidrografica}`);
+  if (empresa.Modalidade && !instalacao.modalidade) linhas.push(`Modalidade da autorização: ${empresa.Modalidade}`);
+  const endereco = formatEndereco(instalacao);
+  if (endereco) linhas.push(endereco.replace(/\n/g, ' • '));
+
+  const titulo = instalacao.nome || instalacao.localizacao || empresa.Instalacao || 'Instalação portuária';
+
+  return `
+    <div style="font-size:14px;color:#1b1b1b;max-width:240px">
+      <strong>${escapeHtml(titulo)}</strong>
+      <div>${linhas.map((linha) => `<div>${escapeHtml(linha)}</div>`).join('')}</div>
+    </div>
+  `;
+}
+
+function construirHtmlMapa(info: TerminalInfo, empresa: Empresa): string {
+  const titulo = info.terminal.nome || info.terminal.localizacao || empresa.Instalacao || 'Instalação';
+  const infoHtml = construirInfoHtml(info.terminal, empresa);
+  const onlineScript = `<script src="${GOOGLE_MAPS_URL}" async defer></script>`;
+
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+    <style>
+      html, body { height: 100%; margin: 0; padding: 0; }
+      #map { height: 100%; width: 100%; }
+    </style>
+    <script type="text/javascript">
+      function initMap() {
+        if (!window.google || !window.google.maps) {
+          return;
+        }
+        var center = { lat: ${info.lat}, lng: ${info.lng} };
+        var map = new google.maps.Map(document.getElementById('map'), {
+          center: center,
+          zoom: 13,
+          mapTypeId: 'roadmap',
+          gestureHandling: 'greedy'
+        });
+        var infoWindow = new google.maps.InfoWindow({ content: ${JSON.stringify(infoHtml)} });
+        var marker = new google.maps.Marker({
+          position: center,
+          map: map,
+          title: ${JSON.stringify(titulo)}
+        });
+        marker.addListener('click', function () {
+          infoWindow.open(map, marker);
+        });
+        infoWindow.open(map, marker);
+      }
+    </script>
+    ${onlineScript}
+  </head>
+  <body>
+    <div id="map"></div>
+  </body>
+</html>`;
+}
+
+export default function MapaInstalacao(): React.JSX.Element {
+  const route = useRoute<MapaRouteProp>();
+  const empresa = route.params.empresa;
+  const {
+    Instalacao,
+    Modalidade,
+    NRInscricao,
+    NORazaoSocial,
+    NORazaoSocialInstalacao,
+    NRInscricaoInstalacao,
+  } = empresa;
+
+  const [instalacoes, setInstalacoes] = useState<InstalacaoPortuaria[]>([]);
+  const [selecionada, setSelecionada] = useState<number>(-1);
+  const [carregando, setCarregando] = useState(true);
+  const [fonteDados, setFonteDados] = useState<DataSource>('online');
+  const [mensagem, setMensagem] = useState<string | null>(null);
+  const [cacheInfo, setCacheInfo] = useState<InstalacoesCache | null>(null);
+  const [online, setOnline] = useState(false);
+  const [snapshot, setSnapshot] = useState<MapSnapshot | null>(null);
+  const [carregandoSnapshot, setCarregandoSnapshot] = useState(false);
+  const [erroSnapshot, setErroSnapshot] = useState<string | null>(null);
+
+  useEffect(() => {
+    let ativo = true;
+
+    async function carregar() {
+      setCarregando(true);
+      setMensagem(null);
+      try {
+        const estadoRede = await NetInfo.fetch();
+        const conectado = Boolean(estadoRede.isConnected && estadoRede.isInternetReachable !== false);
+
+        let lista: InstalacaoPortuaria[] = [];
+        let cacheAtual = await carregarInstalacoesCache(NRInscricao);
+        let origem: DataSource = 'online';
+
+        if (conectado) {
+          try {
+            lista = await consultarInstalacoesPortuarias({
+              cnpj: NRInscricao,
+              instalacao: Instalacao,
+              modalidade: Modalidade,
+            });
+            if (lista.length > 0) {
+              await salvarInstalacoesCache(NRInscricao, lista);
+              cacheAtual = await carregarInstalacoesCache(NRInscricao);
+              origem = 'online';
+            }
+          } catch (err) {
+            const mensagemErro = err instanceof Error ? err.message : 'Erro desconhecido ao consultar instalações.';
+            setMensagem(`Não foi possível atualizar o mapa (${mensagemErro}). Será exibida a última versão salva.`);
+          }
+        }
+
+        if (!lista.length && cacheAtual?.instalacoes?.length) {
+          lista = cacheAtual.instalacoes;
+          origem = cacheAtual.stale ? 'cache-stale' : 'cache';
+        }
+
+        if (!lista.length) {
+          origem = 'empty';
+          setMensagem('Nenhuma instalação com coordenadas foi encontrada para esta empresa.');
+        }
+
+        if (!ativo) return;
+
+        setOnline(conectado);
+        setInstalacoes(lista);
+        setFonteDados(origem);
+        setCacheInfo(cacheAtual ?? null);
+        const indice = pickTerminal(lista, {
+          instalacao: Instalacao,
+          razaoSocialInstalacao: NORazaoSocialInstalacao,
+          razaoSocialEmpresa: NORazaoSocial,
+          inscricaoInstalacao: NRInscricaoInstalacao,
+          inscricaoEmpresa: NRInscricao,
+        });
+        setSelecionada(indice);
+      } finally {
+        if (ativo) {
+          setCarregando(false);
+        }
+      }
+    }
+
+    carregar();
+
+    return () => {
+      ativo = false;
+    };
+  }, [
+    Instalacao,
+    Modalidade,
+    NRInscricao,
+    NORazaoSocial,
+    NORazaoSocialInstalacao,
+    NRInscricaoInstalacao,
+  ]);
+
+  const terminalSelecionado = useMemo<InstalacaoPortuaria | null>(() => {
+    if (selecionada < 0) return null;
+    return instalacoes[selecionada] ?? null;
+  }, [instalacoes, selecionada]);
+
+  const infoTerminal = useMemo<TerminalInfo | null>(() => {
+    if (!terminalSelecionado) return null;
+    const latitude = parseCoordenada(terminalSelecionado.latitude);
+    const longitude = parseCoordenada(terminalSelecionado.longitude);
+    if (latitude == null || longitude == null) return null;
+    return { terminal: terminalSelecionado, lat: latitude, lng: longitude };
+  }, [terminalSelecionado]);
+
+  const htmlMapa = useMemo(() => {
+    if (!infoTerminal) return null;
+    return construirHtmlMapa(infoTerminal, empresa);
+  }, [empresa, infoTerminal]);
+
+  const mapsApiKey = useMemo(() => {
+    const match = GOOGLE_MAPS_URL.match(/[?&]key=([^&]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+  }, []);
+
+  useEffect(() => {
+    let ativo = true;
+    async function carregarSnapshotLocal() {
+      if (!infoTerminal) {
+        if (ativo) setSnapshot(null);
+        return;
+      }
+      const existente = await carregarMapaSnapshot({
+        cnpj: NRInscricao,
+        lat: infoTerminal.lat,
+        lng: infoTerminal.lng,
+        zoom: GOOGLE_STATIC_DEFAULT_ZOOM,
+      });
+      if (ativo) {
+        setSnapshot(existente);
+      }
+    }
+    carregarSnapshotLocal();
+    return () => {
+      ativo = false;
+    };
+  }, [NRInscricao, infoTerminal]);
+
+  useEffect(() => {
+    let cancelado = false;
+    async function atualizarSnapshot() {
+      if (!infoTerminal || !mapsApiKey || !online) {
+        if (!cancelado) {
+          setCarregandoSnapshot(false);
+        }
+        return;
+      }
+      setCarregandoSnapshot(true);
+      setErroSnapshot(null);
+      try {
+        const atualizado = await atualizarMapaSnapshot({
+          apiKey: mapsApiKey,
+          cnpj: NRInscricao,
+          lat: infoTerminal.lat,
+          lng: infoTerminal.lng,
+          zoom: GOOGLE_STATIC_DEFAULT_ZOOM,
+        });
+        if (!cancelado) {
+          setSnapshot(atualizado);
+        }
+      } catch (err) {
+        if (!cancelado) {
+          const mensagemErro =
+            err instanceof Error ? err.message : 'Não foi possível atualizar o mapa offline.';
+          setErroSnapshot(mensagemErro);
+        }
+      } finally {
+        if (!cancelado) {
+          setCarregandoSnapshot(false);
+        }
+      }
+    }
+    atualizarSnapshot();
+    return () => {
+      cancelado = true;
+    };
+  }, [NRInscricao, infoTerminal, mapsApiKey, online]);
+
+  const handleSelecionar = useCallback(
+    (index: number) => {
+      setSelecionada(index);
+    },
+    [],
+  );
+
+  const descricaoFonte = useMemo(() => {
+    switch (fonteDados) {
+      case 'online':
+        return 'Dados atualizados da API';
+      case 'cache':
+        return 'Dados carregados do modo offline';
+      case 'cache-stale':
+        return 'Dados offline desatualizados (sincronize quando possível)';
+      default:
+        return 'Sem dados disponíveis';
+    }
+  }, [fonteDados]);
+
+  const atualizadoEm = useMemo(() => {
+    if (!cacheInfo?.updatedAt) return null;
+    const date = new Date(cacheInfo.updatedAt);
+    return date.toLocaleString('pt-BR');
+  }, [cacheInfo]);
+
+  const snapshotAtualizadoEm = useMemo(() => {
+    if (!snapshot?.createdAt) return null;
+    return new Date(snapshot.createdAt).toLocaleString('pt-BR');
+  }, [snapshot]);
+
+  const snapshotDesatualizado = useMemo(() => snapshotEhAntigo(snapshot), [snapshot]);
+
+  const mostrarMapaOnline = Boolean(htmlMapa && online && !carregando);
+
+  const snapshotAspectRatio = snapshot ? snapshot.width / snapshot.height : 1.5;
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: InstalacaoPortuaria; index: number }) => {
+      const ativo = index === selecionada;
+      const titulo = item.nome || item.localizacao || `Instalação ${index + 1}`;
+      const descricao = formatEndereco(item);
+      const possuiCoordenadas = temCoordenadasValidas(item);
+      return (
+        <Pressable
+          onPress={() => handleSelecionar(index)}
+          style={({ pressed }) => [
+            styles.instalacaoItem,
+            ativo && styles.instalacaoItemAtivo,
+            pressed && styles.instalacaoItemPressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={`Selecionar instalação ${titulo}`}
+        >
+          <Text style={[styles.instalacaoTitulo, ativo && styles.instalacaoTituloAtivo]}>{titulo}</Text>
+          {descricao ? <Text style={styles.instalacaoDescricao}>{descricao}</Text> : null}
+          {!possuiCoordenadas ? (
+            <Text style={styles.instalacaoAviso}>Coordenadas não informadas</Text>
+          ) : null}
+        </Pressable>
+      );
+    },
+    [handleSelecionar, selecionada],
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['left', 'right']}>
+      <View style={styles.header}>
+        <Text style={styles.empresaTitulo}>{NORazaoSocial}</Text>
+        {Modalidade ? <Text style={styles.empresaSubtitulo}>{Modalidade}</Text> : null}
+        <Text style={styles.fonte}>
+          {descricaoFonte}
+          {atualizadoEm ? ` • Atualizado em ${atualizadoEm}` : ''}
+          {!mostrarMapaOnline && snapshotAtualizadoEm
+            ? ` • Mapa offline gerado em ${snapshotAtualizadoEm}`
+            : ''}
+        </Text>
+      </View>
+
+      {mensagem ? <Text style={styles.mensagem}>{mensagem}</Text> : null}
+      {erroSnapshot ? <Text style={styles.mensagem}>{erroSnapshot}</Text> : null}
+      {snapshot && snapshotDesatualizado ? (
+        <Text style={styles.mensagem}>
+          O mapa offline foi gerado há mais de 7 dias. Conecte-se para obter uma imagem atualizada.
+        </Text>
+      ) : null}
+
+      {carregando ? (
+        <View style={styles.loader}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+        </View>
+      ) : null}
+
+      {!carregando && instalacoes.length > 1 ? (
+        <View style={styles.listaWrapper}>
+          <Text style={styles.listaTitulo}>Instalações disponíveis</Text>
+          <FlatList
+            data={instalacoes}
+            keyExtractor={(item, index) => `${item.cdInstalacaoPortuaria || item.nome || index}`}
+            renderItem={renderItem}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.listaContainer}
+          />
+        </View>
+      ) : null}
+
+      <View style={styles.mapaWrapper}>
+        {mostrarMapaOnline ? (
+          <WebView originWhitelist={['*']} source={{ html: htmlMapa ?? '' }} style={styles.webview} />
+        ) : null}
+        {!carregando && !mostrarMapaOnline && snapshot ? (
+          <View style={styles.snapshotWrapper}>
+            <Image
+              source={{ uri: `data:image/png;base64,${snapshot.base64}` }}
+              style={[styles.snapshotImage, { aspectRatio: snapshotAspectRatio }]}
+              resizeMode="cover"
+            />
+            {snapshotAtualizadoEm ? (
+              <Text style={styles.snapshotLegenda}>Mapa offline disponível desde {snapshotAtualizadoEm}.</Text>
+            ) : null}
+          </View>
+        ) : null}
+        {!carregando && !mostrarMapaOnline && !snapshot ? (
+          <View style={styles.semCoordenadas}>
+            <Text style={styles.semCoordenadasTitulo}>Coordenadas indisponíveis</Text>
+            <Text style={styles.semCoordenadasDescricao}>
+              Não foi possível interpretar latitude e longitude para a instalação selecionada.
+            </Text>
+          </View>
+        ) : null}
+        {carregandoSnapshot ? (
+          <View style={styles.snapshotLoader}>
+            <ActivityIndicator size="small" color={theme.colors.primary} />
+            <Text style={styles.snapshotLoaderTexto}>Atualizando cópia offline do mapa…</Text>
+          </View>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.colors.surface },
+  header: { padding: theme.spacing.md, gap: 4 },
+  empresaTitulo: { ...theme.typography.heading },
+  empresaSubtitulo: { ...theme.typography.body, color: theme.colors.muted },
+  fonte: { ...theme.typography.caption, color: theme.colors.muted },
+  mensagem: { ...theme.typography.caption, color: theme.colors.warning, paddingHorizontal: theme.spacing.md },
+  loader: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  listaWrapper: { paddingVertical: theme.spacing.sm },
+  listaTitulo: { ...theme.typography.body, paddingHorizontal: theme.spacing.md, marginBottom: theme.spacing.xs },
+  listaContainer: { paddingHorizontal: theme.spacing.md, gap: theme.spacing.sm },
+  instalacaoItem: {
+    width: 260,
+    padding: theme.spacing.sm,
+    borderRadius: theme.radius.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.background,
+    backgroundColor: theme.colors.background,
+  },
+  instalacaoItemAtivo: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.surface,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  instalacaoItemPressed: { opacity: 0.85 },
+  instalacaoTitulo: { ...theme.typography.body, fontWeight: '600', color: theme.colors.text },
+  instalacaoTituloAtivo: { color: theme.colors.primaryDark },
+  instalacaoDescricao: { ...theme.typography.caption, color: theme.colors.muted, marginTop: theme.spacing.xs },
+  instalacaoAviso: {
+    ...theme.typography.caption,
+    color: theme.colors.warning,
+    marginTop: theme.spacing.xs,
+  },
+  mapaWrapper: {
+    flex: 1,
+    margin: theme.spacing.md,
+    borderRadius: theme.radius.md,
+    overflow: 'hidden',
+    backgroundColor: theme.colors.background,
+  },
+  webview: { flex: 1 },
+  snapshotWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing.md,
+    gap: theme.spacing.sm,
+  },
+  snapshotImage: {
+    width: '100%',
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.surface,
+  },
+  snapshotLegenda: { ...theme.typography.caption, color: theme.colors.muted, textAlign: 'center' },
+  semCoordenadas: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing.md,
+    gap: theme.spacing.sm,
+  },
+  semCoordenadasTitulo: { ...theme.typography.heading, fontSize: 18 },
+  semCoordenadasDescricao: { ...theme.typography.body, color: theme.colors.muted, textAlign: 'center' },
+  snapshotLoader: {
+    position: 'absolute',
+    bottom: theme.spacing.sm,
+    left: theme.spacing.sm,
+    right: theme.spacing.sm,
+    padding: theme.spacing.sm,
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.surface,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing.xs,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 3,
+  },
+  snapshotLoaderTexto: { ...theme.typography.caption, color: theme.colors.muted },
+});
+

--- a/src/screens/HomeFiscalizacao/ConsultarAutorizadas/index.tsx
+++ b/src/screens/HomeFiscalizacao/ConsultarAutorizadas/index.tsx
@@ -13,6 +13,7 @@ import Modalidade from './Modalidade';
 import Embarcacao from './Embarcacao';
 import Instalacao from './Instalacao';
 import Detalhes from './Detalhes';
+import Mapa from './Mapa';
 
 const Stack = createNativeStackNavigator<ConsultarAutorizadasStackParamList>();
 
@@ -45,6 +46,7 @@ export default function ConsultarAutorizadasNavigator(): React.JSX.Element {
       <Stack.Screen name="Embarcacao" component={Embarcacao} options={{ title: 'Por Embarcação' }} />
       <Stack.Screen name="Instalacao" component={Instalacao} options={{ title: 'Por Instalação' }} />
       <Stack.Screen name="Detalhes" component={Detalhes} options={{ title: 'Detalhes da Empresa' }} />
+      <Stack.Screen name="Mapa" component={Mapa} options={{ title: 'Mapa da Instalação' }} />
     </Stack.Navigator>
   );
 }

--- a/src/services/instalacoesCache.ts
+++ b/src/services/instalacoesCache.ts
@@ -1,0 +1,41 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { InstalacaoPortuaria } from '@/api/consultarInstalacoesPortuarias';
+
+const KEY_PREFIX = 'sfis.instalacoes';
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 dias
+
+type CacheEntry = {
+  updatedAt: number;
+  instalacoes: InstalacaoPortuaria[];
+};
+
+const digitsOnly = (value?: string) => (value ? value.replace(/\D/g, '') : '');
+
+const keyFor = (cnpj: string) => `${KEY_PREFIX}:${digitsOnly(cnpj)}`;
+
+export async function salvarInstalacoesCache(
+  cnpj: string,
+  instalacoes: InstalacaoPortuaria[],
+): Promise<void> {
+  const entry: CacheEntry = {
+    updatedAt: Date.now(),
+    instalacoes,
+  };
+  await AsyncStorage.setItem(keyFor(cnpj), JSON.stringify(entry));
+}
+
+export type InstalacoesCache = CacheEntry & { stale: boolean };
+
+export async function carregarInstalacoesCache(cnpj: string): Promise<InstalacoesCache | null> {
+  const raw = await AsyncStorage.getItem(keyFor(cnpj));
+  if (!raw) return null;
+  try {
+    const parsed: CacheEntry = JSON.parse(raw);
+    const stale = Date.now() - parsed.updatedAt > CACHE_TTL_MS;
+    return { ...parsed, stale };
+  } catch {
+    await AsyncStorage.removeItem(keyFor(cnpj));
+    return null;
+  }
+}

--- a/src/services/mapSnapshotCache.ts
+++ b/src/services/mapSnapshotCache.ts
@@ -1,0 +1,160 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY_PREFIX = 'sfis.mapaSnapshot';
+const SNAPSHOT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 dias
+const DEFAULT_ZOOM = 13;
+const DEFAULT_WIDTH = 600;
+const DEFAULT_HEIGHT = 400;
+
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+export type SnapshotParams = {
+  cnpj: string;
+  lat: number;
+  lng: number;
+  zoom?: number;
+  width?: number;
+  height?: number;
+};
+
+export type SnapshotRequest = SnapshotParams & {
+  apiKey: string;
+};
+
+export type MapSnapshot = {
+  base64: string;
+  createdAt: number;
+  lat: number;
+  lng: number;
+  zoom: number;
+  width: number;
+  height: number;
+};
+
+const digitsOnly = (value?: string) => (value ? value.replace(/\D/g, '') : '');
+
+const roundCoord = (value: number) => value.toFixed(5);
+
+const keyFor = ({
+  cnpj,
+  lat,
+  lng,
+  zoom,
+  width,
+  height,
+}: Required<SnapshotParams>): string =>
+  `${KEY_PREFIX}:${digitsOnly(cnpj)}:${zoom}:${width}x${height}:${roundCoord(lat)}:${roundCoord(lng)}`;
+
+const withDefaults = ({
+  cnpj,
+  lat,
+  lng,
+  zoom = DEFAULT_ZOOM,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+}: SnapshotParams): Required<SnapshotParams> => ({ cnpj, lat, lng, zoom, width, height });
+
+/* eslint-disable no-bitwise */
+const encodeBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let output = '';
+
+  for (let i = 0; i < bytes.length; i += 3) {
+    const byte1 = bytes[i];
+    const hasByte2 = i + 1 < bytes.length;
+    const hasByte3 = i + 2 < bytes.length;
+    const byte2 = hasByte2 ? bytes[i + 1] : 0;
+    const byte3 = hasByte3 ? bytes[i + 2] : 0;
+
+    const enc1 = byte1 >> 2;
+    const enc2 = ((byte1 & 0x03) << 4) | (byte2 >> 4);
+    const enc3 = ((byte2 & 0x0f) << 2) | (byte3 >> 6);
+    const enc4 = byte3 & 0x3f;
+
+    output += BASE64_CHARS[enc1];
+    output += BASE64_CHARS[enc2];
+    output += hasByte2 ? BASE64_CHARS[enc3] : '=';
+    output += hasByte3 ? BASE64_CHARS[enc4] : '=';
+  }
+
+  return output;
+};
+/* eslint-enable no-bitwise */
+
+const isStale = (snapshot: MapSnapshot) => Date.now() - snapshot.createdAt > SNAPSHOT_TTL_MS;
+
+export async function carregarMapaSnapshot(params: SnapshotParams): Promise<MapSnapshot | null> {
+  const normalized = withDefaults(params);
+  const key = keyFor(normalized);
+  const raw = await AsyncStorage.getItem(key);
+  if (!raw) return null;
+  try {
+    const parsed: MapSnapshot = JSON.parse(raw);
+    return parsed;
+  } catch {
+    await AsyncStorage.removeItem(key);
+    return null;
+  }
+}
+
+const salvarMapaSnapshot = async (
+  params: Required<SnapshotParams>,
+  base64: string,
+): Promise<MapSnapshot> => {
+  const snapshot: MapSnapshot = {
+    base64,
+    createdAt: Date.now(),
+    lat: params.lat,
+    lng: params.lng,
+    zoom: params.zoom,
+    width: params.width,
+    height: params.height,
+  };
+  await AsyncStorage.setItem(keyFor(params), JSON.stringify(snapshot));
+  return snapshot;
+};
+
+const encodeParam = (key: string, value: string) =>
+  `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+
+const montarStaticMapUrl = (
+  apiKey: string,
+  { lat, lng, zoom, width, height }: Required<SnapshotParams>,
+): string => {
+  const baseUrl = 'https://maps.googleapis.com/maps/api/staticmap';
+  const params = [
+    ['center', `${lat},${lng}`],
+    ['zoom', String(zoom)],
+    ['size', `${width}x${height}`],
+    ['scale', '2'],
+    ['maptype', 'roadmap'],
+    ['markers', `color:red|${lat},${lng}`],
+    ['key', apiKey],
+  ]
+    .map(([key, value]) => encodeParam(key, value))
+    .join('&');
+  return `${baseUrl}?${params}`;
+};
+
+export async function atualizarMapaSnapshot({
+  apiKey,
+  ...params
+}: SnapshotRequest): Promise<MapSnapshot> {
+  const normalized = withDefaults(params);
+  const existente = await carregarMapaSnapshot(normalized);
+  if (existente && !isStale(existente)) {
+    return existente;
+  }
+
+  const url = montarStaticMapUrl(apiKey, normalized);
+  const resposta = await fetch(url);
+  if (!resposta.ok) {
+    throw new Error(`Falha ao gerar mapa offline (${resposta.status})`);
+  }
+  const buffer = await resposta.arrayBuffer();
+  const base64 = encodeBase64(buffer);
+  return salvarMapaSnapshot(normalized, base64);
+}
+
+export const snapshotEhAntigo = (snapshot: MapSnapshot | null) =>
+  snapshot ? isStale(snapshot) : true;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -30,4 +30,7 @@ export type ConsultarAutorizadasStackParamList = {
     Detalhes: {
         empresa: import('@/api/consultarEmpresas').Empresa;
     };
+    Mapa: {
+        empresa: import('@/api/consultarEmpresas').Empresa;
+    };
 };

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,75 @@
+const directionRegex = /[NSEOWnseow]$/;
+
+function normalizeDecimal(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  const parts = trimmed.split(/[^0-9.,-]+/).filter(Boolean);
+  if (parts.length === 0) return trimmed;
+  let normalized = parts.join('');
+  const sign = normalized.startsWith('-') ? '-' : '';
+  normalized = normalized.replace(/^[+-]/, '');
+  normalized = normalized.replace(/,/g, '.');
+  const firstDot = normalized.indexOf('.');
+  if (firstDot >= 0) {
+    normalized = `${normalized.slice(0, firstDot + 1)}${normalized.slice(firstDot + 1).replace(/\./g, '')}`;
+  }
+  return `${sign}${normalized}`;
+}
+
+function convertDMSToDD(degrees: number, minutes: number, seconds: number, direction: string): number {
+  let dd = degrees + minutes / 60 + seconds / 3600;
+  if (/[SWO]/i.test(direction)) {
+    dd *= -1;
+  }
+  return dd;
+}
+
+function parseDms(input: string): number | null {
+  const cleaned = input
+    .replace(/º/g, '°')
+    .replace(/\s+/g, '')
+    .replace(/,/g, '.');
+  const parts = cleaned.split(/[^0-9A-Za-z.]+/).filter(Boolean);
+  if (parts.length < 3) return null;
+
+  let direction = '';
+  const dirIndex = parts.findIndex((part) => /^[NSEOWnseow]$/.test(part));
+  let numbers: string[] = parts;
+  if (dirIndex >= 0) {
+    direction = parts[dirIndex].toUpperCase();
+    numbers = parts.filter((_, index) => index !== dirIndex);
+  } else if (directionRegex.test(cleaned)) {
+    direction = cleaned.slice(-1).toUpperCase();
+  }
+
+  const [degStr, minStr, ...rest] = numbers;
+  const secStr = rest.length >= 2 ? `${rest[0]}.${rest[1]}` : rest[0];
+
+  const degrees = Number(degStr);
+  const minutes = Number(minStr);
+  const seconds = Number((secStr ?? '0').replace(/,/g, '.'));
+
+  if (![degrees, minutes, seconds].every((n) => Number.isFinite(n))) {
+    return null;
+  }
+
+  return convertDMSToDD(degrees, minutes, seconds, direction);
+}
+
+function parseDecimal(input: string): number | null {
+  const normalized = normalizeDecimal(input);
+  if (!normalized) return null;
+  const value = Number(normalized);
+  return Number.isFinite(value) ? value : null;
+}
+
+export function parseCoordenada(raw?: string | null): number | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (/[°º'"NSEOWnseow]/.test(trimmed)) {
+    const dms = parseDms(trimmed);
+    if (dms != null) return dms;
+  }
+  return parseDecimal(trimmed);
+}


### PR DESCRIPTION
## Resumo
- remove o script legado do Google Maps offline e gera HTML apenas quando há conexão
- cria serviço para baixar e versionar snapshots do Google Static Maps e reaproveitá-los nas consultas
- exibe imagem offline e avisos de atualização na tela de mapa e ajusta o texto de ajuda nos detalhes

## Testes
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9e28857c4832aba6cafd524b30ffe