### PR TITLE
Melhora parsing de coordenadas para mapa offline

### DIFF
--- a/__tests__/geo.test.ts
+++ b/__tests__/geo.test.ts
@@ -1,0 +1,27 @@
+import { parseCoordenada } from '@/utils/geo';
+
+describe('parseCoordenada', () => {
+  it('interpreta coordenadas DMS com rótulos em português', () => {
+    const latitude = parseCoordenada("Latitude: 12°27'5,4\" Sul");
+    expect(latitude).not.toBeNull();
+    expect(latitude ?? 0).toBeCloseTo(-12.4515, 4);
+  });
+
+  it('interpreta coordenadas DMS com direção extensa e segundos fracionados', () => {
+    const longitude = parseCoordenada('Longitude Oeste 64°13\'44,03"');
+    expect(longitude).not.toBeNull();
+    expect(longitude ?? 0).toBeCloseTo(-64.2288972, 4);
+  });
+
+  it('interpreta segundos separados por espaço', () => {
+    const longitude = parseCoordenada('64°13\'44 03\" Oeste');
+    expect(longitude).not.toBeNull();
+    expect(longitude ?? 0).toBeCloseTo(-64.2288972, 4);
+  });
+
+  it('aceita direções abreviadas alternativas', () => {
+    const longitude = parseCoordenada('8°3\'15\" Leste');
+    expect(longitude).not.toBeNull();
+    expect(longitude ?? 0).toBeCloseTo(8.0541666, 4);
+  });
+});


### PR DESCRIPTION
## Summary
- normaliza textos e direções em português ao interpretar coordenadas em DMS
- trata frações de segundos separadas e remove rótulos não numéricos antes de converter valores
- adiciona testes unitários para garantir o suporte aos novos formatos de coordenadas

## Testing
- npm test -- --runTestsByPath __tests__/geo.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9f2835538832a9307ec96930caaf0