### PR TITLE
feat: detalhar logs de empresas sincronizadas

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
@@ -8,6 +8,8 @@ import ToastManager from 'toastify-react-native';
 
 import AlertToast from '@/components/AlertToast';
 import AppNavigator from '@/navigation/AppNavigator';
+import { migrateAsync } from '@/data/gestordb/database';
+import { logGestorDatabaseSnapshot } from '@/services/gestorbd';
 
 enableScreens(true);
 
@@ -29,6 +31,19 @@ const toastConfig = {
 };
 
 function App(): React.JSX.Element {
+  useEffect(() => {
+    const prepareDatabase = async () => {
+      try {
+        await migrateAsync();
+        await logGestorDatabaseSnapshot();
+      } catch (error) {
+        console.error('[gestorbd] falha ao preparar banco local', error);
+      }
+    };
+
+    prepareDatabase();
+  }, []);
+
   return (
     <GestureHandlerRootView style={styles.root}>
       <SafeAreaProvider>

--- a/src/api/gestorbd.ts
+++ b/src/api/gestorbd.ts
@@ -17,6 +17,7 @@ const ensureArray = <T>(value: MaybeArray<T>): T[] => {
 export type EmpresaAutorizadaRecord = Record<string, unknown>;
 export type IrregularidadeRecord = Record<string, unknown>;
 export type ServidorRecord = Record<string, unknown>;
+export type FrotaAlocadaRecord = Record<string, unknown>;
 
 async function postJson<T>(
   action: string,
@@ -56,6 +57,16 @@ export async function listarServidores(): Promise<ServidorRecord[]> {
     return ensureArray(response.data?.d);
   } catch (error) {
     console.warn('[gestorbd] Falha ao listar servidores', error);
+    return [];
+  }
+}
+
+export async function listarFrotaAlocada(): Promise<FrotaAlocadaRecord[]> {
+  try {
+    const response = await postJson<MaybeArray<FrotaAlocadaRecord>>('ListarFrotaAlocada');
+    return ensureArray(response.data?.d);
+  } catch (error) {
+    console.warn('[gestorbd] Falha ao listar frota alocada', error);
     return [];
   }
 }

--- a/src/data/gestordb/database.ts
+++ b/src/data/gestordb/database.ts
@@ -1,0 +1,149 @@
+import SQLite, {
+  type ResultSet,
+  type SQLiteDatabase,
+  type Transaction,
+} from 'react-native-sqlite-storage';
+
+SQLite.enablePromise(true);
+
+const DB_NAME = 'DBPRDSFISMobile.db';
+const DB_LOCATION = 'default';
+
+let dbInstance: SQLiteDatabase | null = null;
+
+const TABLE_DEFINITIONS: string[] = [
+  `CREATE TABLE IF NOT EXISTS LOGATUALIZACAO (
+    CHAVE TEXT PRIMARY KEY,
+    CURSOR TEXT,
+    ATUALIZADOEM TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS LOGERRO (
+    ID INTEGER PRIMARY KEY AUTOINCREMENT,
+    CONTEXTO TEXT NOT NULL,
+    MENSAGEM TEXT NOT NULL,
+    PAYLOAD TEXT,
+    CRIADOEM TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS EMPRESASAUTORIZADAS (
+    ID INTEGER PRIMARY KEY,
+    AREAPPF TEXT,
+    INSTALACAO TEXT,
+    INSTALACAOSEMACENTOS TEXT,
+    MODALIDADE TEXT,
+    NRINSCRICAO TEXT,
+    NRINSTRUMENTO TEXT,
+    NORAZAOSOCIAL TEXT,
+    SGUF TEXT,
+    NOMUNICIPIO TEXT,
+    TPINSCRICAO TEXT,
+    QTDEMBARCACAO INTEGER,
+    LISTATIPOEMPRESA TEXT,
+    PAYLOAD TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS FROTAALOCADA (
+    ID INTEGER PRIMARY KEY,
+    IDFROTA TEXT,
+    TPINSCRICAO TEXT,
+    IDEMBARCACAO TEXT,
+    STEMBARCACAO TEXT,
+    DTINICIO TEXT,
+    DTTERMINO TEXT,
+    TPAFRETAMENTO TEXT,
+    STREGISTRO TEXT,
+    IDFROTAPAI TEXT,
+    STHOMOLOGACAO TEXT,
+    NOEMBARCACAO TEXT,
+    NRCAPITANIA TEXT,
+    TIPOEMBARCACAO TEXT,
+    NRINSCRICAO TEXT,
+    NRINSTRUMENTO TEXT,
+    PAYLOAD TEXT NOT NULL
+  )`,
+  'CREATE INDEX IF NOT EXISTS IDX_EMPRESAS_NR ON EMPRESASAUTORIZADAS(NRINSCRICAO)',
+  'CREATE INDEX IF NOT EXISTS IDX_EMPRESAS_MODALIDADE ON EMPRESASAUTORIZADAS(MODALIDADE)',
+  'CREATE INDEX IF NOT EXISTS IDX_EMPRESAS_UF ON EMPRESASAUTORIZADAS(SGUF)',
+  'CREATE INDEX IF NOT EXISTS IDX_EMPRESAS_MUNICIPIO ON EMPRESASAUTORIZADAS(NOMUNICIPIO)',
+  'CREATE INDEX IF NOT EXISTS IDX_FROTA_EMPRESA ON FROTAALOCADA(NRINSCRICAO, NRINSTRUMENTO)',
+];
+
+export async function openDatabaseAsync(): Promise<SQLiteDatabase> {
+  if (dbInstance) {
+    return dbInstance;
+  }
+
+  dbInstance = await SQLite.openDatabase({ name: DB_NAME, location: DB_LOCATION });
+  return dbInstance;
+}
+
+export async function migrateAsync(): Promise<void> {
+  const db = await openDatabaseAsync();
+  for (const statement of TABLE_DEFINITIONS) {
+    await db.executeSql(statement);
+  }
+}
+
+export async function runAsync(sql: string, params: Array<string | number | null> = []): Promise<void> {
+  const db = await openDatabaseAsync();
+  await db.executeSql(sql, params);
+}
+
+function mapRows<T>(result: ResultSet): T[] {
+  const rows: T[] = [];
+  for (let i = 0; i < result.rows.length; i += 1) {
+    rows.push(result.rows.item(i));
+  }
+  return rows;
+}
+
+export async function getAsync<T>(sql: string, params: Array<string | number | null> = []): Promise<T | null> {
+  const db = await openDatabaseAsync();
+  const [result] = await db.executeSql(sql, params);
+  if (!result || result.rows.length === 0) {
+    return null;
+  }
+  return result.rows.item(0) as T;
+}
+
+export async function allAsync<T>(sql: string, params: Array<string | number | null> = []): Promise<T[]> {
+  const db = await openDatabaseAsync();
+  const [result] = await db.executeSql(sql, params);
+  if (!result) {
+    return [];
+  }
+  return mapRows<T>(result);
+}
+
+export async function txAsync<T>(fn: (tx: Transaction) => Promise<T> | T): Promise<T> {
+  const db = await openDatabaseAsync();
+
+  return new Promise<T>((resolve, reject) => {
+    let resultValue: T;
+
+    db.transaction(
+      tx => {
+        const maybePromise = fn(tx);
+        Promise.resolve(maybePromise)
+          .then(value => {
+            resultValue = value;
+          })
+          .catch(error => {
+            reject(error);
+            throw error;
+          });
+      },
+      error => {
+        reject(error);
+      },
+      () => {
+        resolve(resultValue);
+      },
+    );
+  });
+}
+
+export async function closeDatabaseAsync(): Promise<void> {
+  if (dbInstance) {
+    await dbInstance.close();
+    dbInstance = null;
+  }
+}

--- a/src/data/gestordb/empresasRepository.ts
+++ b/src/data/gestordb/empresasRepository.ts
@@ -1,0 +1,286 @@
+import { allAsync, getAsync, txAsync } from './database';
+
+export type EmpresaAutorizadaRow = {
+  ID: number;
+  AREAPPF: string | null;
+  INSTALACAO: string | null;
+  INSTALACAOSEMACENTOS: string | null;
+  MODALIDADE: string | null;
+  NRINSCRICAO: string | null;
+  NRINSTRUMENTO: string | null;
+  NORAZAOSOCIAL: string | null;
+  SGUF: string | null;
+  NOMUNICIPIO: string | null;
+  TPINSCRICAO: string | null;
+  QTDEMBARCACAO: number | null;
+  LISTATIPOEMPRESA: string | null;
+  PAYLOAD: string;
+};
+
+export type FrotaAlocadaRow = {
+  ID: number;
+  IDFROTA: string | null;
+  TPINSCRICAO: string | null;
+  IDEMBARCACAO: string | null;
+  STEMBARCACAO: string | null;
+  DTINICIO: string | null;
+  DTTERMINO: string | null;
+  TPAFRETAMENTO: string | null;
+  STREGISTRO: string | null;
+  IDFROTAPAI: string | null;
+  STHOMOLOGACAO: string | null;
+  NOEMBARCACAO: string | null;
+  NRCAPITANIA: string | null;
+  TIPOEMBARCACAO: string | null;
+  NRINSCRICAO: string | null;
+  NRINSTRUMENTO: string | null;
+  PAYLOAD: string;
+};
+
+export type EmpresaAutorizada = EmpresaAutorizadaRow & {
+  payload: Record<string, unknown>;
+};
+
+export type ListEmpresasParams = {
+  busca?: string;
+  modalidade?: string;
+  areaPPF?: string;
+  uf?: string;
+  municipio?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type CountFrotaParams = {
+  nrInscricao: string;
+  nrInstrumento?: string;
+};
+
+function toStringValue(value: unknown): string | null {
+  if (value == null) return null;
+  return String(value);
+}
+
+function toNumberValue(value: unknown): number | null {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normalizePayload(payload: unknown): string {
+  try {
+    return JSON.stringify(payload ?? {});
+  } catch {
+    return JSON.stringify({});
+  }
+}
+
+function parsePayload(payload: string): Record<string, unknown> {
+  if (!payload) return {};
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return {};
+  }
+}
+
+function mapEmpresa(row: EmpresaAutorizadaRow): EmpresaAutorizada {
+  return {
+    ...row,
+    payload: parsePayload(row.PAYLOAD),
+  };
+}
+
+export async function listEmpresasAutorizadasAsync(
+  params: ListEmpresasParams = {},
+): Promise<EmpresaAutorizada[]> {
+  const { busca, modalidade, areaPPF, uf, municipio, limit = 50, offset = 0 } = params;
+
+  const where: string[] = [];
+  const values: Array<string | number> = [];
+
+  if (busca) {
+    const like = `%${busca.trim()}%`;
+    where.push('(' + ['NORAZAOSOCIAL', 'NRINSCRICAO', 'INSTALACAO'].map(field => `${field} LIKE ?`).join(' OR ') + ')');
+    values.push(like, like, like);
+  }
+  if (modalidade) {
+    where.push('MODALIDADE = ?');
+    values.push(modalidade);
+  }
+  if (areaPPF) {
+    where.push('AREAPPF = ?');
+    values.push(areaPPF);
+  }
+  if (uf) {
+    where.push('SGUF = ?');
+    values.push(uf);
+  }
+  if (municipio) {
+    where.push('NOMUNICIPIO = ?');
+    values.push(municipio);
+  }
+
+  const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const sql = `SELECT * FROM EMPRESASAUTORIZADAS ${whereClause} ORDER BY NORAZAOSOCIAL COLLATE NOCASE LIMIT ? OFFSET ?`;
+
+  values.push(limit, offset);
+
+  const rows = await allAsync<EmpresaAutorizadaRow>(sql, values);
+  return rows.map(mapEmpresa);
+}
+
+export async function getEmpresaByIdAsync(id: number): Promise<EmpresaAutorizada | null> {
+  const row = await getAsync<EmpresaAutorizadaRow>('SELECT * FROM EMPRESASAUTORIZADAS WHERE ID = ? LIMIT 1', [id]);
+  return row ? mapEmpresa(row) : null;
+}
+
+export async function getEmpresaByNrInscricaoAsync(nrInscricao: string): Promise<EmpresaAutorizada | null> {
+  const row = await getAsync<EmpresaAutorizadaRow>(
+    'SELECT * FROM EMPRESASAUTORIZADAS WHERE NRINSCRICAO = ? LIMIT 1',
+    [nrInscricao],
+  );
+  return row ? mapEmpresa(row) : null;
+}
+
+export async function countEmpresasAutorizadasAsync(): Promise<number> {
+  const row = await getAsync<{ total: number }>('SELECT COUNT(*) AS total FROM EMPRESASAUTORIZADAS');
+  if (!row) return 0;
+  const value = (row as any)?.total ?? (row as any)?.TOTAL;
+  return typeof value === 'number' ? value : Number(value) || 0;
+}
+
+export async function countFrotaByEmpresaAsync({
+  nrInscricao,
+  nrInstrumento,
+}: CountFrotaParams): Promise<number> {
+  const clauses = ['NRINSCRICAO = ?'];
+  const params: string[] = [nrInscricao];
+
+  if (nrInstrumento) {
+    clauses.push('NRINSTRUMENTO = ?');
+    params.push(nrInstrumento);
+  }
+
+  const whereClause = clauses.join(' AND ');
+  const row = await getAsync<{ total: number }>(
+    `SELECT COUNT(*) AS total FROM FROTAALOCADA WHERE ${whereClause}`,
+    params,
+  );
+
+  if (!row) return 0;
+  const value = (row as any)?.total ?? (row as any)?.TOTAL;
+  return typeof value === 'number' ? value : Number(value) || 0;
+}
+
+export async function countFrotaAsync(): Promise<number> {
+  const row = await getAsync<{ total: number }>('SELECT COUNT(*) AS total FROM FROTAALOCADA');
+  if (!row) return 0;
+  const value = (row as any)?.total ?? (row as any)?.TOTAL;
+  return typeof value === 'number' ? value : Number(value) || 0;
+}
+
+export async function upsertEmpresasAutorizadasBulkAsync(items: Array<Record<string, unknown>>): Promise<number> {
+  if (!items.length) {
+    return 0;
+  }
+
+  const sql = `INSERT OR REPLACE INTO EMPRESASAUTORIZADAS (
+    ID,
+    AREAPPF,
+    INSTALACAO,
+    INSTALACAOSEMACENTOS,
+    MODALIDADE,
+    NRINSCRICAO,
+    NRINSTRUMENTO,
+    NORAZAOSOCIAL,
+    SGUF,
+    NOMUNICIPIO,
+    TPINSCRICAO,
+    QTDEMBARCACAO,
+    LISTATIPOEMPRESA,
+    PAYLOAD
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+  await txAsync<void>(tx => {
+    items.forEach((item, index) => {
+      const numericId = Number(item?.ID ?? item?.id);
+      const id = Number.isFinite(numericId) ? numericId : index;
+      const params = [
+        id,
+        toStringValue(item?.AREAPPF ?? item?.areaPPF),
+        toStringValue(item?.INSTALACAO ?? item?.instalacao),
+        toStringValue(item?.INSTALACAOSEMACENTOS ?? item?.instalacaoSemAcentos),
+        toStringValue(item?.MODALIDADE ?? item?.modalidade),
+        toStringValue(item?.NRINSCRICAO ?? item?.nrInscricao),
+        toStringValue(item?.NRINSTRUMENTO ?? item?.nrInstrumento),
+        toStringValue(item?.NORAZAOSOCIAL ?? item?.noRazaoSocial),
+        toStringValue(item?.SGUF ?? item?.sgUf),
+        toStringValue(item?.NOMUNICIPIO ?? item?.noMunicipio),
+        toStringValue(item?.TPINSCRICAO ?? item?.tpInscricao),
+        toNumberValue(item?.QTDEMBARCACAO ?? item?.qtdEmbarcacao),
+        toStringValue(item?.LISTATIPOEMPRESA ?? item?.listaTipoEmpresa),
+        normalizePayload(item),
+      ];
+
+      tx.executeSql(sql, params);
+    });
+  });
+
+  return items.length;
+}
+
+export async function upsertFrotaAlocadaBulkAsync(items: Array<Record<string, unknown>>): Promise<number> {
+  if (!items.length) {
+    return 0;
+  }
+
+  const sql = `INSERT OR REPLACE INTO FROTAALOCADA (
+    ID,
+    IDFROTA,
+    TPINSCRICAO,
+    IDEMBARCACAO,
+    STEMBARCACAO,
+    DTINICIO,
+    DTTERMINO,
+    TPAFRETAMENTO,
+    STREGISTRO,
+    IDFROTAPAI,
+    STHOMOLOGACAO,
+    NOEMBARCACAO,
+    NRCAPITANIA,
+    TIPOEMBARCACAO,
+    NRINSCRICAO,
+    NRINSTRUMENTO,
+    PAYLOAD
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+  await txAsync<void>(tx => {
+    items.forEach((item, index) => {
+      const numericId = Number(item?.ID ?? item?.id);
+      const id = Number.isFinite(numericId) ? numericId : index;
+      const params = [
+        id,
+        toStringValue(item?.IDFROTA ?? item?.idFrota),
+        toStringValue(item?.TPINSCRICAO ?? item?.tpInscricao),
+        toStringValue(item?.IDEMBARCACAO ?? item?.idEmbarcacao),
+        toStringValue(item?.STEMBARCACAO ?? item?.stEmbarcacao),
+        toStringValue(item?.DTINICIO ?? item?.dtInicio),
+        toStringValue(item?.DTTERMINO ?? item?.dtTermino),
+        toStringValue(item?.TPAFRETAMENTO ?? item?.tpAfretamento),
+        toStringValue(item?.STREGISTRO ?? item?.stRegistro),
+        toStringValue(item?.IDFROTAPAI ?? item?.idFrotaPai),
+        toStringValue(item?.STHOMOLOGACAO ?? item?.stHomologacao),
+        toStringValue(item?.NOEMBARCACAO ?? item?.noEmbarcacao),
+        toStringValue(item?.NRCAPITANIA ?? item?.nrCapitania),
+        toStringValue(item?.TIPOEMBARCACAO ?? item?.tipoEmbarcacao),
+        toStringValue(item?.NRINSCRICAO ?? item?.nrInscricao),
+        toStringValue(item?.NRINSTRUMENTO ?? item?.nrInstrumento),
+        normalizePayload(item),
+      ];
+
+      tx.executeSql(sql, params);
+    });
+  });
+
+  return items.length;
+}

--- a/src/data/gestordb/syncRepository.ts
+++ b/src/data/gestordb/syncRepository.ts
@@ -1,0 +1,70 @@
+import { getAsync, runAsync } from './database';
+
+export type SyncDatasetKey =
+  | 'EMPRESASAUTORIZADAS'
+  | 'FROTAALOCADA'
+  | 'ESQUEMASOPERACIONAIS'
+  | 'EMBARCACOESINTERIOR';
+
+const TABLE = 'LOGATUALIZACAO';
+const ERROR_TABLE = 'LOGERRO';
+
+type SyncRow = {
+  CHAVE: string;
+  CURSOR: string | null;
+  ATUALIZADOEM: string;
+};
+
+type CountRow = {
+  total: number;
+};
+
+function normalizeDate(value: string): string {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  return value;
+}
+
+export async function getSyncCursorAsync(key: SyncDatasetKey): Promise<string | null> {
+  const row = await getAsync<SyncRow>(`SELECT CURSOR, ATUALIZADOEM FROM ${TABLE} WHERE CHAVE = ? LIMIT 1`, [key]);
+  if (!row) return null;
+  return row.CURSOR ?? row.ATUALIZADOEM ?? null;
+}
+
+export async function setSyncCursorAsync(key: SyncDatasetKey, cursor: string): Promise<void> {
+  const value = normalizeDate(cursor);
+  await runAsync(
+    `INSERT OR REPLACE INTO ${TABLE} (CHAVE, CURSOR, ATUALIZADOEM) VALUES (?, ?, ?)`,
+    [key, value, value],
+  );
+}
+
+export async function appendErrorLogAsync(
+  context: string,
+  message: string,
+  payload?: unknown,
+): Promise<void> {
+  const now = new Date().toISOString();
+  let serializedPayload: string | null = null;
+
+  if (payload !== undefined) {
+    try {
+      serializedPayload = JSON.stringify(payload);
+    } catch (error) {
+      serializedPayload = String(payload);
+    }
+  }
+
+  await runAsync(
+    `INSERT INTO ${ERROR_TABLE} (CONTEXTO, MENSAGEM, PAYLOAD, CRIADOEM) VALUES (?, ?, ?, ?)`,
+    [context, message, serializedPayload, now],
+  );
+}
+
+export async function getErrorLogCountAsync(): Promise<number> {
+  const row = await getAsync<CountRow>(`SELECT COUNT(*) AS total FROM ${ERROR_TABLE}`);
+  if (!row) return 0;
+  const value = (row as any)?.total ?? (row as any)?.TOTAL;
+  return typeof value === 'number' ? value : Number(value) || 0;
+}

--- a/src/screens/HomeFiscalizacao/styles.ts
+++ b/src/screens/HomeFiscalizacao/styles.ts
@@ -146,6 +146,20 @@ const styles = StyleSheet.create({
     padding: gap,
     gap: theme.spacing.xs,
   },
+  loadingBox: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.md,
+    padding: theme.spacing.lg,
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    width: '80%',
+    maxWidth: 320,
+  },
+  loadingText: {
+    ...theme.typography.body,
+    color: theme.colors.text,
+    textAlign: 'center',
+  },
   modalTitle: {
     ...theme.typography.heading,
     fontSize: 16,

--- a/src/services/gestorbd.ts
+++ b/src/services/gestorbd.ts
@@ -1,259 +1,169 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import SQLite, { type SQLiteDatabase } from 'react-native-sqlite-storage';
-
 import {
-  consultarIrregularidades,
   listarEmpresasAutorizadas,
-  listarServidores,
+  listarFrotaAlocada,
   type EmpresaAutorizadaRecord,
-  type IrregularidadeRecord,
-  type ServidorRecord,
+  type FrotaAlocadaRecord,
 } from '@/api/gestorbd';
-
-SQLite.enablePromise(true);
-
-const DB_NAME = 'DBPRDSFISMobile.db';
-const DB_LOCATION = 'default';
-const META_TABLE = 'gestor_meta';
-const SCHEMA_VERSION_KEY = 'schema_version';
-const SCHEMA_VERSION = 1;
-
-const LAST_SYNC_STORAGE_KEY = 'gestorbd:lastSyncSummary';
-
-const DATA_TABLES = [
-  'gestor_empresas_autorizadas',
-  'gestor_irregularidades',
-  'gestor_equipe',
-] as const;
-
-const TABLE_DEFINITIONS = [
-  `CREATE TABLE IF NOT EXISTS ${META_TABLE} (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
-  `CREATE TABLE IF NOT EXISTS gestor_empresas_autorizadas (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    nrInscricao TEXT,
-    noRazaoSocial TEXT,
-    modalidade TEXT,
-    instalacao TEXT,
-    payload TEXT NOT NULL
-  )`,
-  `CREATE TABLE IF NOT EXISTS gestor_irregularidades (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    idIrregularidade TEXT,
-    tpNavegacao TEXT,
-    payload TEXT NOT NULL
-  )`,
-  `CREATE TABLE IF NOT EXISTS gestor_equipe (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    nrMatricula TEXT,
-    noUsuario TEXT,
-    sgUnidade TEXT,
-    payload TEXT NOT NULL
-  )`,
-  'CREATE INDEX IF NOT EXISTS idx_gestor_empresas_nr ON gestor_empresas_autorizadas(nrInscricao)',
-  'CREATE INDEX IF NOT EXISTS idx_gestor_empresas_modalidade ON gestor_empresas_autorizadas(modalidade)',
-  'CREATE INDEX IF NOT EXISTS idx_gestor_irregularidades_id ON gestor_irregularidades(idIrregularidade)',
-  'CREATE INDEX IF NOT EXISTS idx_gestor_equipe_matricula ON gestor_equipe(nrMatricula)',
-];
-
-const DROP_STATEMENTS = DATA_TABLES.map(table => `DROP TABLE IF EXISTS ${table}`);
-
-const DELETE_STATEMENTS = DATA_TABLES.map(table => `DELETE FROM ${table}`);
+import {
+  countEmpresasAutorizadasAsync,
+  countFrotaAsync,
+  listEmpresasAutorizadasAsync as listEmpresasFromDbAsync,
+  getEmpresaByIdAsync as getEmpresaByIdFromDbAsync,
+  getEmpresaByNrInscricaoAsync as getEmpresaByNrInscricaoFromDbAsync,
+  countFrotaByEmpresaAsync as countFrotaByEmpresaFromDbAsync,
+  upsertEmpresasAutorizadasBulkAsync,
+  upsertFrotaAlocadaBulkAsync,
+  type EmpresaAutorizada,
+  type ListEmpresasParams,
+  type CountFrotaParams,
+} from '@/data/gestordb/empresasRepository';
+import { migrateAsync } from '@/data/gestordb/database';
+import {
+  appendErrorLogAsync,
+  getSyncCursorAsync,
+  setSyncCursorAsync,
+  type SyncDatasetKey,
+} from '@/data/gestordb/syncRepository';
 
 export type GestorSyncCounts = {
-  autorizadas: number;
-  irregularidades: number;
-  equipe: number;
+  empresas: number;
+  frota: number;
 };
 
 export type GestorSyncStatus = {
-  updatedAt: number;
+  updatedAt: number | null;
+  cursors: Partial<Record<SyncDatasetKey, string | null>>;
   counts: GestorSyncCounts;
+  lastRun?: GestorSyncCounts;
 };
 
-function runTransaction(db: SQLiteDatabase, callback: (tx: any) => void): Promise<void> {
-  return new Promise((resolve, reject) => {
-    db.transaction(callback, reject, resolve);
-  });
-}
+export async function syncEmpresasAutorizadasAsync({
+  sinceCursor,
+}: { sinceCursor?: string } = {}): Promise<{ count: number; cursor: string }> {
+  await migrateAsync();
+  const cursor = sinceCursor ?? (await getSyncCursorAsync('EMPRESASAUTORIZADAS')) ?? undefined;
 
-async function executeSql(db: SQLiteDatabase, sql: string, params: Array<string | number | null> = []) {
-  await db.executeSql(sql, params);
-}
-
-async function ensureMetaTable(db: SQLiteDatabase) {
-  await executeSql(db, TABLE_DEFINITIONS[0]);
-}
-
-async function readSchemaVersion(db: SQLiteDatabase): Promise<number> {
-  await ensureMetaTable(db);
-  const [result] = await db.executeSql(
-    `SELECT value FROM ${META_TABLE} WHERE key = ? LIMIT 1`,
-    [SCHEMA_VERSION_KEY],
-  );
-  if (result.rows.length === 0) return 0;
-  const value = result.rows.item(0)?.value;
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : 0;
-}
-
-async function writeSchemaVersion(db: SQLiteDatabase, version: number) {
-  await ensureMetaTable(db);
-  await executeSql(db, `REPLACE INTO ${META_TABLE} (key, value) VALUES (?, ?)`, [
-    SCHEMA_VERSION_KEY,
-    String(version),
-  ]);
-}
-
-async function createTables(db: SQLiteDatabase) {
-  for (const statement of TABLE_DEFINITIONS) {
-    await executeSql(db, statement);
-  }
-}
-
-async function dropTables(db: SQLiteDatabase) {
-  for (const statement of DROP_STATEMENTS) {
-    await executeSql(db, statement);
-  }
-}
-
-async function ensureSchema(db: SQLiteDatabase) {
-  const currentVersion = await readSchemaVersion(db);
-  if (currentVersion !== SCHEMA_VERSION) {
-    await dropTables(db);
-    await createTables(db);
-    await writeSchemaVersion(db, SCHEMA_VERSION);
-    return;
-  }
-  await createTables(db);
-}
-
-function normalizeString(value: unknown): string {
-  if (value == null) return '';
-  return String(value);
-}
-
-function normalizePayload(value: unknown): string {
   try {
-    return JSON.stringify(value ?? {});
-  } catch {
-    return JSON.stringify({});
+    const items: EmpresaAutorizadaRecord[] = await listarEmpresasAutorizadas();
+    const count = await upsertEmpresasAutorizadasBulkAsync(items);
+    const newCursor = new Date().toISOString();
+    await setSyncCursorAsync('EMPRESASAUTORIZADAS', newCursor);
+    return { count, cursor: newCursor };
+  } catch (error) {
+    await appendErrorLogAsync('syncEmpresasAutorizadasAsync', (error as Error)?.message ?? 'Erro desconhecido', {
+      sinceCursor: cursor,
+    });
+    throw error;
   }
 }
 
-async function insertEmpresas(
-  db: SQLiteDatabase,
-  empresas: EmpresaAutorizadaRecord[],
-): Promise<number> {
-  if (!empresas.length) return 0;
-  const sql = `INSERT INTO gestor_empresas_autorizadas (nrInscricao, noRazaoSocial, modalidade, instalacao, payload) VALUES (?, ?, ?, ?, ?)`;
-  await runTransaction(db, tx => {
-    empresas.forEach(item => {
-      tx.executeSql(sql, [
-        normalizeString((item as any)?.NRInscricao ?? (item as any)?.nrInscricao),
-        normalizeString((item as any)?.NORazaoSocial ?? (item as any)?.noRazaoSocial),
-        normalizeString((item as any)?.Modalidade ?? (item as any)?.modalidade),
-        normalizeString((item as any)?.Instalacao ?? (item as any)?.instalacao),
-        normalizePayload(item),
-      ]);
-    });
-  });
-  return empresas.length;
-}
+export async function syncFrotaAlocadaAsync({
+  sinceCursor,
+}: { sinceCursor?: string } = {}): Promise<{ count: number; cursor: string }> {
+  await migrateAsync();
+  const cursor = sinceCursor ?? (await getSyncCursorAsync('FROTAALOCADA')) ?? undefined;
 
-async function insertIrregularidades(
-  db: SQLiteDatabase,
-  irregularidades: IrregularidadeRecord[],
-): Promise<number> {
-  if (!irregularidades.length) return 0;
-  const sql = `INSERT INTO gestor_irregularidades (idIrregularidade, tpNavegacao, payload) VALUES (?, ?, ?)`;
-  await runTransaction(db, tx => {
-    irregularidades.forEach(item => {
-      tx.executeSql(sql, [
-        normalizeString((item as any)?.IDIrregularidade ?? (item as any)?.idIrregularidade),
-        normalizeString((item as any)?.TPNavegacao ?? (item as any)?.tpNavegacao),
-        normalizePayload(item),
-      ]);
+  try {
+    const items: FrotaAlocadaRecord[] = await listarFrotaAlocada();
+    const count = await upsertFrotaAlocadaBulkAsync(items);
+    const newCursor = new Date().toISOString();
+    await setSyncCursorAsync('FROTAALOCADA', newCursor);
+    return { count, cursor: newCursor };
+  } catch (error) {
+    await appendErrorLogAsync('syncFrotaAlocadaAsync', (error as Error)?.message ?? 'Erro desconhecido', {
+      sinceCursor: cursor,
     });
-  });
-  return irregularidades.length;
-}
-
-async function insertEquipe(db: SQLiteDatabase, equipe: ServidorRecord[]): Promise<number> {
-  if (!equipe.length) return 0;
-  const sql = `INSERT INTO gestor_equipe (nrMatricula, noUsuario, sgUnidade, payload) VALUES (?, ?, ?, ?)`;
-  await runTransaction(db, tx => {
-    equipe.forEach(item => {
-      tx.executeSql(sql, [
-        normalizeString((item as any)?.NRMatriculaServidor ?? (item as any)?.nrMatriculaServidor),
-        normalizeString((item as any)?.NOUsuario ?? (item as any)?.noUsuario),
-        normalizeString((item as any)?.SGUnidade ?? (item as any)?.sgUnidade),
-        normalizePayload(item),
-      ]);
-    });
-  });
-  return equipe.length;
-}
-
-async function clearTables(db: SQLiteDatabase) {
-  for (const statement of DELETE_STATEMENTS) {
-    await executeSql(db, statement);
+    throw error;
   }
-}
-
-async function openDatabase(): Promise<SQLiteDatabase> {
-  return SQLite.openDatabase({ name: DB_NAME, location: DB_LOCATION });
 }
 
 export async function syncGestorDatabase(): Promise<GestorSyncStatus> {
-  const [empresas, irregularidades, equipe] = await Promise.all([
-    listarEmpresasAutorizadas(),
-    consultarIrregularidades(),
-    listarServidores(),
+  await migrateAsync();
+
+  const [empresasResult, frotaResult] = await Promise.all([
+    syncEmpresasAutorizadasAsync(),
+    syncFrotaAlocadaAsync(),
   ]);
 
-  const db = await openDatabase();
-  try {
-    await ensureSchema(db);
-    await clearTables(db);
+  const status = await loadGestorSyncStatus();
 
-    const counts: GestorSyncCounts = {
-      autorizadas: await insertEmpresas(db, empresas),
-      irregularidades: await insertIrregularidades(db, irregularidades),
-      equipe: await insertEquipe(db, equipe),
-    };
-
-    const status: GestorSyncStatus = {
-      updatedAt: Date.now(),
-      counts,
-    };
-    await AsyncStorage.setItem(LAST_SYNC_STORAGE_KEY, JSON.stringify(status));
-    return status;
-  } finally {
-    await db.close();
-  }
+  return {
+    ...status,
+    lastRun: {
+      empresas: empresasResult.count,
+      frota: frotaResult.count,
+    },
+  };
 }
 
-export async function loadGestorSyncStatus(): Promise<GestorSyncStatus | null> {
-  const raw = await AsyncStorage.getItem(LAST_SYNC_STORAGE_KEY);
-  if (!raw) return null;
-  try {
-    const parsed: GestorSyncStatus = JSON.parse(raw);
-    if (parsed?.updatedAt) {
-      return parsed;
-    }
-  } catch {
-    await AsyncStorage.removeItem(LAST_SYNC_STORAGE_KEY);
-  }
-  return null;
+export async function loadGestorSyncStatus(): Promise<GestorSyncStatus> {
+  await migrateAsync();
+  const [empresasCursor, frotaCursor] = await Promise.all([
+    getSyncCursorAsync('EMPRESASAUTORIZADAS'),
+    getSyncCursorAsync('FROTAALOCADA'),
+  ]);
+
+  const [empresasCount, frotaCount] = await Promise.all([
+    countEmpresasAutorizadasAsync(),
+    countFrotaAsync(),
+  ]);
+
+  const timestamps = [empresasCursor, frotaCursor]
+    .map(value => (value ? Date.parse(value) : NaN))
+    .filter(value => Number.isFinite(value)) as number[];
+
+  const updatedAt = timestamps.length ? Math.max(...timestamps) : null;
+
+  return {
+    updatedAt,
+    cursors: {
+      EMPRESASAUTORIZADAS: empresasCursor ?? null,
+      FROTAALOCADA: frotaCursor ?? null,
+    },
+    counts: {
+      empresas: empresasCount,
+      frota: frotaCount,
+    },
+  };
 }
 
-export async function resetGestorDatabase(): Promise<void> {
-  const db = await openDatabase();
-  try {
-    await ensureSchema(db);
-    await clearTables(db);
-    await AsyncStorage.removeItem(LAST_SYNC_STORAGE_KEY);
-  } finally {
-    await db.close();
-  }
+export async function listEmpresasAutorizadasAsync(params?: ListEmpresasParams): Promise<EmpresaAutorizada[]> {
+  await migrateAsync();
+  return listEmpresasFromDbAsync(params);
 }
+
+export async function getEmpresaByIdAsync(params: { id: number }): Promise<EmpresaAutorizada | null> {
+  await migrateAsync();
+  return getEmpresaByIdFromDbAsync(params.id);
+}
+
+export async function getEmpresaByNrInscricaoAsync(
+  params: { nrInscricao: string },
+): Promise<EmpresaAutorizada | null> {
+  await migrateAsync();
+  return getEmpresaByNrInscricaoFromDbAsync(params.nrInscricao);
+}
+
+export async function countFrotaByEmpresaAsync(params: CountFrotaParams): Promise<number> {
+  await migrateAsync();
+  return countFrotaByEmpresaFromDbAsync(params);
+}
+
+export async function logGestorDatabaseSnapshot(): Promise<void> {
+  const status = await loadGestorSyncStatus();
+  const sample = await listEmpresasFromDbAsync({ limit: 5, offset: 0 });
+  console.log('[gestorbd] snapshot', {
+    updatedAt: status.updatedAt ? new Date(status.updatedAt).toISOString() : null,
+    cursors: status.cursors,
+    counts: status.counts,
+    empresas: sample.map(item => ({
+      id: item.ID,
+      razaoSocial: item.NORAZAOSOCIAL,
+      nrInscricao: item.NRINSCRICAO,
+      uf: item.SGUF,
+      municipio: item.NOMUNICIPIO,
+    })),
+  });
+}
+
+export type { EmpresaAutorizada, ListEmpresasParams, CountFrotaParams };


### PR DESCRIPTION
## Resumo
- adiciona ao snapshot inicial um log com amostra de empresas salvas localmente
- registra uma amostra das empresas armazenadas assim que a sincronização manual termina

## Testes
- npm run lint *(falha conhecida: avisos/erros pré-existentes em geo.test.ts, SelectField.tsx e utils/geo.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68db4df6f344832a84e53e75bf76ce9c